### PR TITLE
Update instructions for 9.0 upgrade

### DIFF
--- a/UPGRADE-9.0.md
+++ b/UPGRADE-9.0.md
@@ -6,11 +6,49 @@ You need to search and replace all namespace in your code:
 before
 
 ```php
-SpiriitLexik\Bundle\FormFilterBundle
+Lexik\Bundle\FormFilterBundle
 ```
 
 after
 
 ```php
 Spiriit\Bundle\FormFilterBundle
-``
+```
+
+
+In `bundles.php`:
+
+before
+
+```php
+use Lexik\Bundle\FormFilterBundle\LexikFormFilterBundle;
+
+...
+
+LexikFormFilterBundle::class => ['all' => true],
+```
+
+after
+
+```php
+use Spiriit\Bundle\FormFilterBundle\SpiriitFormFilterBundle;
+
+...
+
+SpiriitFormFilterBundle::class => ['all' => true],
+```
+
+
+In `lexik_form_filter.yaml` / `lexik_form_filter.php` bundle configuration file:
+
+before
+
+```php
+lexik_form_filter
+```
+
+after
+
+```php
+spiriit_form_filter
+```


### PR DESCRIPTION
There was a small typo ("SpiriitLexik" instead of just "Lexik") in the upgrade readme. I took the opportunity to also add the additional changes that have to be made in `bundles.php` and the bundle configuration file to complete the switch from `lexik/form-filter-bundle` to `spiriitlabs/form-filter-bundle`. The bundle registration is covered by the recipe but I figured it couldn't hurt to include it too.

I would suggest to move the information about the namespace change from the [issue](https://github.com/lexik/LexikFormFilterBundle/issues/369) directly to the top of the [readme of the original repo](https://github.com/lexik/LexikFormFilterBundle/blob/master/README.md), so its more visible.

The new `SpiriitLabs/form-filter-bundle` repo also currently has issues disabled... unless thats intentional.. ;) 