### PR TITLE
Add return type annotation

### DIFF
--- a/SpiriitFormFilterBundle.php
+++ b/SpiriitFormFilterBundle.php
@@ -23,6 +23,8 @@ class SpiriitFormFilterBundle extends Bundle
 {
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function build(ContainerBuilder $container)
     {


### PR DESCRIPTION
Fixes Symfony deprecation

Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Spiriit\Bundle\FormFilterBundle\SpiriitFormFilterBundle" now to avoid errors or add an explicit @return annotation to suppress this message.