### PR TITLE
Update doc for Symfony 6

### DIFF
--- a/Resources/doc/basics.md
+++ b/Resources/doc/basics.md
@@ -92,7 +92,7 @@ class DefaultController extends Controller
 
         if ($request->query->has($form->getName())) {
             // manually bind values from the request
-            $form->submit($request->query->get($form->getName()));
+            $form->submit($request->query->all($form->getName()));
 
             // initialize a query builder
             $filterBuilder = $this->get('doctrine.orm.entity_manager')


### PR DESCRIPTION
Change from
$request->query->get
to
$request->query->all

because of Symfony 6 ( https://github.com/symfony/symfony/pull/41766#issuecomment-865083005 ). 

This change prevent this error: "Input value "..." contains a non-scalar value."