### PR TITLE
MongoRegex deprecated

### DIFF
--- a/Event/Subscriber/DoctrineMongodbSubscriber.php
+++ b/Event/Subscriber/DoctrineMongodbSubscriber.php
@@ -278,7 +278,7 @@ class DoctrineMongodbSubscriber implements EventSubscriberInterface
         if ('' !== $values['value'] && null !== $values['value']) {
             $pattern = $values['condition_pattern'] ?? FilterOperands::STRING_CONTAINS;
 
-            $patternValues = [FilterOperands::STRING_STARTS => new \MongoRegex('/^' . $values['value'] . '.*/i'), FilterOperands::STRING_ENDS => new \MongoRegex('/.*' . $values['value'] . '$/i'), FilterOperands::STRING_CONTAINS => new \MongoRegex('/.*' . $values['value'] . '.*/i'), FilterOperands::STRING_EQUALS => $values['value']];
+            $patternValues = [FilterOperands::STRING_STARTS => new \MongoDB\BSON\Regex('^' . $values['value'] . '.*', 'i'), FilterOperands::STRING_ENDS => new \MongoDB\BSON\Regex('.*' . $values['value'] . '$', 'i'), FilterOperands::STRING_CONTAINS => new \MongoDB\BSON\Regex('.*' . $values['value'] . '.*', 'i'), FilterOperands::STRING_EQUALS => $values['value']];
 
             if (!isset($patternValues[$pattern])) {
                 throw new \InvalidArgumentException('Wrong type constant in string like expression mapper.');

--- a/Tests/Filter/Doctrine/MongodbQueryBuilderUpdaterTest.php
+++ b/Tests/Filter/Doctrine/MongodbQueryBuilderUpdaterTest.php
@@ -46,10 +46,10 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         $year = '2019';
 
         $bson = ['{}', '{"$and":[{"name":"blabla"}]}', '{"$and":[{"name":"blabla"},{"position":{"$gt":2}}]}', '{"$and":[{"name":"blabla"},{"position":{"$gt":2}},{"enabled":true}]}', '{"$and":[{"name":"blabla"},{"position":{"$gt":2}},{"enabled":true}]}', [
-            '{"$and":[{"name":{"regex":".*blabla$","flags":"i"}},{"position":{"$lte":2}},{"createdAt":{"$date":{"$numberLong":"1569535200000"}}}]}',
+            '{"$and":[{"name":{"$regex":".*blabla$","$options":"i"}},{"position":{"$lte":2}},{"createdAt":{"$date":{"$numberLong":"1569535200000"}}}]}',
             '{"$and":[{"name":"\/.*blabla$\/i"},{"position":{"$lte":2}},{"createdAt":{"$date":{"$numberLong":"1569535200000"}}}]}'
         ], [
-            '{"$and":[{"name":{"regex":".*blabla$","flags":"i"}},{"position":{"$lte":2}},{"createdAt":{"$date":{"$numberLong":"1569583260000"}}}]}',
+            '{"$and":[{"name":{"$regex":".*blabla$","$options":"i"}},{"position":{"$lte":2}},{"createdAt":{"$date":{"$numberLong":"1569583260000"}}}]}',
             '{"$and":[{"name":"\/.*blabla$\/i"},{"position":{"$lte":2}},{"createdAt":{"$date":{"$numberLong":"1569583260000"}}}]}'
         ]];
 
@@ -244,7 +244,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         $this->assertContains(
             $this->toBson($mongoQB->getQueryArray()),
             [
-                '{"$and":[{"name":{"regex":".*hey dude.*","flags":"i"}},{"position":99}]}',
+                '{"$and":[{"name":{"$regex":".*hey dude.*","$options":"i"}},{"position":99}]}',
                 '{"$and":[{"name":"\/.*hey dude.*\/i"},{"position":99}]}'
             ]
         );


### PR DESCRIPTION
`MongoRegex` has been deprecated, it is recommended to use `MongoDB\BSON\Regex` from the `MongoDB` extension, which `mongodb-odm-bundle` also uses.