### PR TITLE
Fix error with doctrine/orm 3.0: ClassMetadataInfo is now ClassMetadata

### DIFF
--- a/Event/Subscriber/DoctrineORMSubscriber.php
+++ b/Event/Subscriber/DoctrineORMSubscriber.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\QueryBuilder;
 use Spiriit\Bundle\FormFilterBundle\Event\GetFilterConditionEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -89,7 +89,7 @@ class DoctrineORMSubscriber extends AbstractDoctrineSubscriber implements EventS
                 $fieldName = ltrim($event->getField(), $rootPart->getAlias() . '.');
                 $metadata = $queryBuilder->getEntityManager()->getClassMetadata($rootPart->getFrom());
 
-                if (isset($metadata->associationMappings[$fieldName]) && (!$metadata->associationMappings[$fieldName]['isOwningSide'] || $metadata->associationMappings[$fieldName]['type'] === ClassMetadataInfo::MANY_TO_MANY)) {
+                if (isset($metadata->associationMappings[$fieldName]) && (!$metadata->associationMappings[$fieldName]['isOwningSide'] || $metadata->associationMappings[$fieldName]['type'] === ClassMetadata::MANY_TO_MANY)) {
                     if (!$event->getFilterQuery()->hasJoinAlias($fieldName)) {
                         $queryBuilder->leftJoin($event->getField(), $fieldName);
                     }


### PR DESCRIPTION
In ORM 3.0, `Doctrine\ORM\Mapping\ClassMetadataInfo` is removed, so `Doctrine\ORM\Mapping\ClassMetadata` must be used.