### PR TITLE
Fix apostrophe handling in filterText method using parameterized queries

### DIFF
--- a/Event/Subscriber/AbstractDoctrineSubscriber.php
+++ b/Event/Subscriber/AbstractDoctrineSubscriber.php
@@ -232,15 +232,20 @@ abstract class AbstractDoctrineSubscriber
      */
     public function filterText(GetFilterConditionEvent $event)
     {
-        $expr = $event->getFilterQuery()->getExpressionBuilder();
+        $expr = $event->getFilterQuery()->getExpr();
+        $expression = $expr->andX();
         $values = $event->getValues();
 
         if ('' !== $values['value'] && null !== $values['value']) {
+            $paramName = sprintf('p_%s', str_replace('.', '_', $event->getField()));
+
             if (isset($values['condition_pattern'])) {
-                $event->setCondition($expr->stringLike($event->getField(), $values['value'], $values['condition_pattern']));
+                $expression->add($expr->like($event->getField(), ':' . $paramName, $values['condition_pattern']));
             } else {
-                $event->setCondition($expr->stringLike($event->getField(), $values['value']));
+                $expression->add($expr->like($event->getField(), ':' . $paramName));
             }
+
+            $event->setCondition($expression, [$paramName => $values['value']]);
         }
     }
 


### PR DESCRIPTION
This change addresses a bug where text inputs containing apostrophes were not escaped correctly, leading to query errors. Using parameterized queries ensures proper handling of such inputs.


