### PR TITLE
Fix deprecation warning from passing null to str_replace

### DIFF
--- a/Event/Subscriber/DoctrineORMSubscriber.php
+++ b/Event/Subscriber/DoctrineORMSubscriber.php
@@ -88,7 +88,7 @@ class DoctrineORMSubscriber extends AbstractDoctrineSubscriber implements EventS
 
             if ($dqlFrom = $event->getQueryBuilder()->getDQLPart('from')) {
                 $rootPart = reset($dqlFrom);
-                $fieldName = \str_replace(\sprintf('%s.', $rootPart->getAlias()), null, $event->getField());
+                $fieldName = \str_replace(\sprintf('%s.', $rootPart->getAlias()), '', $event->getField());
                 $metadata = $queryBuilder->getEntityManager()->getClassMetadata($rootPart->getFrom());
 
                 if (isset($metadata->associationMappings[$fieldName]) && (!$metadata->associationMappings[$fieldName]['isOwningSide'] || $metadata->associationMappings[$fieldName]['type'] === ClassMetadata::MANY_TO_MANY)) {


### PR DESCRIPTION
The second argument to `str_replace` should be empty string rather than null. Otherwise you get this error:
```
Deprecated: str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated
```