### PR TITLE
Remove usage of the deprecated base extension from HttpKernel

### DIFF
--- a/DependencyInjection/SpiriitFormFilterExtension.php
+++ b/DependencyInjection/SpiriitFormFilterExtension.php
@@ -14,9 +14,9 @@ namespace Spiriit\Bundle\FormFilterBundle\DependencyInjection;
 use Spiriit\Bundle\FormFilterBundle\Filter\FilterOperands;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration


### PR DESCRIPTION
The base extension available in HttpKernel only adds support for registering some classes to be added in the cache warmer of the doctrine/annotations parser, compared to the base class of the DI component. As annotations are not supported anymore in Symfony 7, this base class has been deprecated in Symfony 7.1. As this bundle does not rely on the extra feature, it can use the base class from DI directly.