### PR TITLE
Avoid PHP 8.4 deprecation "Implicitly marking parameter as nullable"

### DIFF
--- a/Filter/Condition/ConditionNode.php
+++ b/Filter/Condition/ConditionNode.php
@@ -42,7 +42,7 @@ class ConditionNode implements ConditionNodeInterface
      * @param string                 $operator
      * @param ConditionNodeInterface $parent
      */
-    public function __construct($operator, ConditionNodeInterface $parent = null)
+    public function __construct($operator, ?ConditionNodeInterface $parent = null)
     {
         $this->operator = $operator;
         $this->parent = $parent;

--- a/Filter/FilterBuilderExecuter.php
+++ b/Filter/FilterBuilderExecuter.php
@@ -74,7 +74,7 @@ class FilterBuilderExecuter implements FilterBuilderExecuterInterface
     /**
      * {@inheritdoc}
      */
-    public function addOnce($join, $alias, \Closure $callback = null)
+    public function addOnce($join, $alias, ?\Closure $callback = null)
     {
         if ($this->parts->has($join)) {
             return null;

--- a/Filter/FilterBuilderExecuterInterface.php
+++ b/Filter/FilterBuilderExecuterInterface.php
@@ -25,7 +25,7 @@ interface FilterBuilderExecuterInterface
      * @param string   $alias
      * @param \Closure $callback
      */
-    public function addOnce($join, $alias, \Closure $callback = null);
+    public function addOnce($join, $alias, ?\Closure $callback = null);
 
     /**
      * @return string


### PR DESCRIPTION
Since PHP 8.4 Implicitly marking parameter as nullable is deprecated.
This is easy to fix using the explicit nullable type introduced in PHP 7.1

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

