### PR TITLE
Connection::PARAM:STR_ARRAY is deprecated in DBAL 4.x

### DIFF
--- a/Event/Subscriber/AbstractDoctrineSubscriber.php
+++ b/Event/Subscriber/AbstractDoctrineSubscriber.php
@@ -39,9 +39,10 @@ abstract class AbstractDoctrineSubscriber
             $paramName = $this->generateParameterName($event->getField());
 
             if (is_array($values['value']) && sizeof($values['value']) > 0) {
+                $parameterType = class_exists(ArrayParameterType::class) ? ArrayParameterType::STRING : Connection::PARAM_STR_ARRAY;
                 $event->setCondition(
                     $expr->in($event->getField(), ':' . $paramName),
-                    [$paramName => [$values['value'], Connection::PARAM_STR_ARRAY]]
+                    [$paramName => [$values['value'], $parameterType]]
                 );
             } elseif (!is_array($values['value'])) {
                 $event->setCondition(


### PR DESCRIPTION
Since the constant Connection::PARAM_STR_ARRAY is deprecated in DBAL 4.x, we need to check if it is available or not. Otherwise, we will use the Constant ArrayParameterType::STRING from the Types Class.